### PR TITLE
Enable individual assertion messages to be shown in verbose mode

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -31,7 +31,7 @@ module.exports = function( grunt ){
         begin : function(){
 
         },
-        testDone : function( suite, name, totalAssertions, passedAssertions, failedAssertions, skippedAssertions ){
+        testDone : function( suite, name, totalAssertions, passedAssertions, failedAssertions, skippedAssertions, assertions ){
             status.specs++;
             status.failed += failedAssertions;
             status.passed += passedAssertions;
@@ -51,8 +51,18 @@ module.exports = function( grunt ){
             }else{
                 if( failedAssertions > 0 ){
                     if( errorReporting ){
-                        grunt.log.write( testName.red );
-                        grunt.log.error();
+
+                        grunt.log.writeln();
+                        grunt.log.writeln( testName.red );
+
+                        // show assertions
+                        JSON.parse(assertions).forEach(function(assertion) {
+
+                            var color = assertion.passed ? 'green' : 'red';
+                            grunt.log.writeln('> ' + assertion.message[color]);
+
+                        });
+
                     }else{
                         grunt.log.write( 'F'.red );
                     }

--- a/tasks/jasmine/jasmine-helper.js
+++ b/tasks/jasmine/jasmine-helper.js
@@ -47,7 +47,22 @@ GruntReporter.prototype = {
     reportSpecResults : function( spec ){
         var results = spec.results();
         var suites = this._getSuitesToRoot( spec.suite );
-        sendMessage( 'testDone', suites.join( ' ' ), spec.description, results.totalCount, results.passedCount, results.failedCount, results.skipped );
+        var items = [];
+
+        if (results.failedCount) {
+
+            items = results.getItems().map(function(item) {
+                return {
+                    message: item.message,
+                    passed:  item.passed()
+                };
+            });
+
+        }
+
+        var assertions = JSON.stringify(items);
+
+        sendMessage( 'testDone', suites.join( ' ' ), spec.description, results.totalCount, results.passedCount, results.failedCount, results.skipped, assertions );
     }
 };
 


### PR DESCRIPTION
When a test fails we get the name of the failing test but not the reason it failed:

![before](https://f.cloud.github.com/assets/926283/2019442/1ebbee74-8823-11e3-8a54-891e2fcbb9a7.png)

Perhaps we could show the assertion results ( only in verbose mode ) to give a little more info back to the user:

![showassertions](https://f.cloud.github.com/assets/926283/2019447/4149e90a-8823-11e3-998c-d704ec04108a.png)

What say you?
